### PR TITLE
Exclude unnecessary files from package

### DIFF
--- a/EngageF3.Build
+++ b/EngageF3.Build
@@ -414,6 +414,8 @@
     <exclude name="_ReSharper.*/**"/>
     <exclude name="**/obj/**"/>
     <exclude name="${referencesDirectory}/**"/>
+    <exclude name="**/bin/**"/>
+    <exclude name="CustomDictionary.xml"/>
   </patternset>
   <patternset id="source.fileset">
     <include name="**/*.js"/>
@@ -435,6 +437,7 @@
     <include name="??.??.??.txt" />
     <include name="MSBuild/*.dll"/>
     <include name="MSBuild/*.targets"/>
+    <include name="CustomDictionary.xml"/>
     <exclude name="**/obj/**"/>
     <exclude name="Release.txt" />
   </patternset>


### PR DESCRIPTION
Excluding 'bin' folder and 'CustomDictionary.xml' from Resources.zip in the install package.
